### PR TITLE
Add stuff needed for use in Omicron

### DIFF
--- a/diffus-derive/src/lib.rs
+++ b/diffus-derive/src/lib.rs
@@ -4,24 +4,37 @@ use quote::{format_ident, quote};
 
 type Output = proc_macro2::TokenStream;
 
+// Is the field tagged with `#[diffus_ignore]` ?
+fn has_ignore_attr(field: &syn::Field) -> bool {
+    field
+        .attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("diffus_ignore"))
+}
+
 fn edit_fields(fields: &syn::Fields, lifetime: &syn::Lifetime) -> Output {
-    let edit_fields = fields.iter().map(|field| match field {
-        syn::Field {
-            ident: Some(ident),
-            ty,
-            vis,
-            ..
-        } => quote! {
-            #vis #ident: diffus::edit::Edit<#lifetime, #ty>
-        },
-        syn::Field {
-            ident: None,
-            ty,
-            vis,
-            ..
-        } => quote! {
-            #vis diffus::edit::Edit<#lifetime, #ty>
-        },
+    let edit_fields = fields.iter().filter_map(|field| {
+        if has_ignore_attr(field) {
+            return None;
+        }
+        Some(match field {
+            syn::Field {
+                ident: Some(ident),
+                ty,
+                vis,
+                ..
+            } => quote! {
+                #vis #ident: diffus::edit::Edit<#lifetime, #ty>
+            },
+            syn::Field {
+                ident: None,
+                ty,
+                vis,
+                ..
+            } => quote! {
+                #vis diffus::edit::Edit<#lifetime, #ty>
+            },
+        })
     });
 
     quote! { #(#edit_fields),* }
@@ -42,10 +55,12 @@ fn field_ident(enumerated_field: (usize, &syn::Field), prefix: &str) -> syn::Ide
 }
 
 fn field_idents(fields: &syn::Fields, prefix: &str) -> Output {
-    let field_idents = fields
-        .iter()
-        .enumerate()
-        .map(|enumerated_field| field_ident(enumerated_field, prefix));
+    let field_idents = fields.iter().enumerate().filter_map(|enumerated_field| {
+        if has_ignore_attr(enumerated_field.1) {
+            return None;
+        }
+        Some(field_ident(enumerated_field, prefix))
+    });
 
     quote! { #(#field_idents),* }
 }
@@ -67,17 +82,22 @@ fn renamed_field_ident(enumerated_field: (usize, &syn::Field), prefix: &str) -> 
 }
 
 fn renamed_field_idents(fields: &syn::Fields, prefix: &str) -> Output {
-    let field_idents = fields
-        .iter()
-        .enumerate()
-        .map(|enumerated_field| renamed_field_ident(enumerated_field, prefix));
+    let field_idents = fields.iter().enumerate().filter_map(|enumerated_field| {
+        if has_ignore_attr(enumerated_field.1) {
+            return None;
+        }
+        Some(renamed_field_ident(enumerated_field, prefix))
+    });
 
     quote! { #(#field_idents),* }
 }
 
 fn matches_all_copy(fields: &syn::Fields) -> Output {
-    let edit_fields_copy = fields.iter().enumerate().map(|_| {
-        quote! { diffus::edit::Edit::Copy(_) }
+    let edit_fields_copy = fields.iter().enumerate().filter_map(|(_, field)| {
+        if has_ignore_attr(field) {
+            return None;
+        }
+        Some(quote! { diffus::edit::Edit::Copy(_) })
     });
 
     quote! {
@@ -86,7 +106,10 @@ fn matches_all_copy(fields: &syn::Fields) -> Output {
 }
 
 fn field_diffs(fields: &syn::Fields) -> Output {
-    let field_diffs = fields.iter().enumerate().map(|(index, field)| {
+    let field_diffs = fields.iter().enumerate().filter_map(|(index, field)| {
+        if has_ignore_attr(field) {
+            return None;
+        }
         let field_name = match field {
             syn::Field {
                 ident: Some(ident), ..
@@ -98,9 +121,9 @@ fn field_diffs(fields: &syn::Fields) -> Output {
             }
         };
 
-        quote! {
+        Some(quote! {
             diffus::Diffable::diff(&self.#field_name, &other.#field_name)
-        }
+        })
     });
 
     quote! { #(#field_diffs),* }
@@ -132,7 +155,7 @@ fn input_lifetime(generics: &syn::Generics) -> Option<&syn::Lifetime> {
     lifetime
 }
 
-#[proc_macro_derive(Diffus)]
+#[proc_macro_derive(Diffus, attributes(diffus_ignore))]
 pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: syn::DeriveInput = syn::parse2(proc_macro2::TokenStream::from(input)).unwrap();
 
@@ -145,10 +168,11 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     let default_lifetime = syn::parse_str::<syn::Lifetime>("'diffus_a").unwrap();
     let impl_lifetime = data_lifetime.unwrap_or(&default_lifetime);
 
+    // Always derive `Debug`
     #[cfg(feature = "serialize-impl")]
-    let derive_serialize = Some(quote! { #[derive(serde::Serialize)] });
+    let derive_serialize = Some(quote! { #[derive(serde::Serialize, Debug)] });
     #[cfg(not(feature = "serialize-impl"))]
-    let derive_serialize: Option<proc_macro2::TokenStream> = None;
+    let derive_serialize: Option<proc_macro2::TokenStream> = Some(quote! { #[derive(Debug)] });
 
     proc_macro::TokenStream::from(match input.data {
         syn::Data::Enum(syn::DataEnum { variants, .. }) => {

--- a/diffus/src/diffable_impls/borrow.rs
+++ b/diffus/src/diffable_impls/borrow.rs
@@ -49,6 +49,7 @@ mod tests {
         let left = 13;
         let right = 37;
 
+        #[allow(unused_allocation)]
         if let edit::Edit::Change(diff) = Box::new(left).diff(&Box::new(right)) {
             assert_eq!(*diff, (&13, &37));
         }

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -32,16 +32,16 @@ macro_rules! ip_impl {
 
                 fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
                     match (self, other) {
-                        (left @ $typ::V4(a), right @ $typ::V4(b)) => match a.diff(&b) {
+                        ($typ::V4(a), $typ::V4(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
                             }
                         },
-                        (left @ $typ::V6(a), right @ $typ::V6(b)) => match a.diff(&b) {
+                        ($typ::V6(a), $typ::V6(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
                             }
                         },
                         _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -2,7 +2,7 @@ use crate::{
     edit::{self, enm},
     Diffable,
 };
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 macro_rules! struct_impl {
     ($($typ:ty),*) => {
@@ -24,6 +24,7 @@ macro_rules! struct_impl {
 
 struct_impl! { Ipv4Addr, Ipv6Addr,  SocketAddrV4, SocketAddrV6}
 
+// TODO: Macro for these enums
 impl<'a> Diffable<'a> for IpAddr {
     type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
 
@@ -36,6 +37,28 @@ impl<'a> Diffable<'a> for IpAddr {
                 }
             },
             (left @ IpAddr::V6(a), right @ IpAddr::V6(b)) => match a.diff(&b) {
+                edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                edit::Edit::Change(_) => {
+                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                }
+            },
+            _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+        }
+    }
+}
+
+impl<'a> Diffable<'a> for SocketAddr {
+    type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
+
+    fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+        match (self, other) {
+            (left @ SocketAddr::V4(a), right @ SocketAddr::V4(b)) => match a.diff(&b) {
+                edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                edit::Edit::Change(_) => {
+                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                }
+            },
+            (left @ SocketAddr::V6(a), right @ SocketAddr::V6(b)) => match a.diff(&b) {
                 edit::Edit::Copy(_) => edit::Edit::Copy(self),
                 edit::Edit::Change(_) => {
                     edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -1,0 +1,100 @@
+use crate::{
+    edit::{self, enm},
+    Diffable,
+};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+macro_rules! struct_impl {
+    ($($typ:ty),*) => {
+        $(
+            impl<'a> Diffable<'a> for $typ {
+                type Diff = (&'a $typ, &'a $typ);
+
+                fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+                    if self == other {
+                        edit::Edit::Copy(self)
+                    } else {
+                        edit::Edit::Change((self, other))
+                    }
+                }
+            }
+        )*
+    }
+}
+
+struct_impl! { Ipv4Addr, Ipv6Addr,  SocketAddrV4, SocketAddrV6}
+
+impl<'a> Diffable<'a> for IpAddr {
+    type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
+
+    fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+        match (self, other) {
+            (left @ IpAddr::V4(a), right @ IpAddr::V4(b)) => match a.diff(&b) {
+                edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                edit::Edit::Change(_) => {
+                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                }
+            },
+            (left @ IpAddr::V6(a), right @ IpAddr::V6(b)) => match a.diff(&b) {
+                edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                edit::Edit::Change(_) => {
+                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                }
+            },
+            _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_copy() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        assert!(localhost_v4.clone().diff(&localhost_v4).is_copy());
+        assert!(localhost_v6.clone().diff(&localhost_v6).is_copy());
+        assert!(Some(3).diff(&Some(3)).is_copy());
+    }
+
+    #[test]
+    fn associate_change() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let not_localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        let not_localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2));
+        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
+            localhost_v4.diff(&not_localhost_v4).change()
+        {
+            assert_eq!(a, localhost_v4);
+            assert_eq!(b, not_localhost_v4);
+            assert_ne!(a, b);
+        } else {
+            unreachable!();
+        }
+
+        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
+            localhost_v6.diff(&not_localhost_v6).change()
+        {
+            assert_eq!(a, localhost_v6);
+            assert_eq!(b, not_localhost_v6);
+            assert_ne!(a, b);
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn variant_changed() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        if let Some(enm::Edit::VariantChanged(&a, &b)) = localhost_v4.diff(&localhost_v6).change() {
+            assert_eq!(a, localhost_v4);
+            assert_eq!(b, localhost_v6);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -24,50 +24,35 @@ macro_rules! struct_impl {
 
 struct_impl! { Ipv4Addr, Ipv6Addr,  SocketAddrV4, SocketAddrV6}
 
-// TODO: Macro for these enums
-impl<'a> Diffable<'a> for IpAddr {
-    type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
+macro_rules! ip_impl {
+    ($($typ:tt),*) => {
+        $(
+            impl<'a> Diffable<'a> for $typ {
+                type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
 
-    fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
-        match (self, other) {
-            (left @ IpAddr::V4(a), right @ IpAddr::V4(b)) => match a.diff(&b) {
-                edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(_) => {
-                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+                    match (self, other) {
+                        (left @ $typ::V4(a), right @ $typ::V4(b)) => match a.diff(&b) {
+                            edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                            edit::Edit::Change(_) => {
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                            }
+                        },
+                        (left @ $typ::V6(a), right @ $typ::V6(b)) => match a.diff(&b) {
+                            edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                            edit::Edit::Change(_) => {
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
+                            }
+                        },
+                        _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+                    }
                 }
-            },
-            (left @ IpAddr::V6(a), right @ IpAddr::V6(b)) => match a.diff(&b) {
-                edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(_) => {
-                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
-                }
-            },
-            _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
-        }
+            }
+        )*
     }
 }
 
-impl<'a> Diffable<'a> for SocketAddr {
-    type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
-
-    fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
-        match (self, other) {
-            (left @ SocketAddr::V4(a), right @ SocketAddr::V4(b)) => match a.diff(&b) {
-                edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(_) => {
-                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
-                }
-            },
-            (left @ SocketAddr::V6(a), right @ SocketAddr::V6(b)) => match a.diff(&b) {
-                edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(_) => {
-                    edit::Edit::Change(enm::Edit::AssociatedChanged((left, right)))
-                }
-            },
-            _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
-        }
-    }
-}
+ip_impl! { IpAddr, SocketAddr }
 
 #[cfg(test)]
 mod tests {

--- a/diffus/src/diffable_impls/mod.rs
+++ b/diffus/src/diffable_impls/mod.rs
@@ -1,5 +1,6 @@
 pub mod borrow;
 pub mod collection;
+pub mod ip;
 pub mod map;
 pub mod option;
 pub mod primitives;

--- a/diffus/src/diffable_impls/primitives.rs
+++ b/diffus/src/diffable_impls/primitives.rs
@@ -19,6 +19,8 @@ macro_rules! primitive_impl {
     }
 }
 
+pub(crate) use primitive_impl;
+
 primitive_impl! { i64, i32, i16, i8, u64, u32, u16, u8, char, bool, isize, usize, f32, f64, () }
 
 #[cfg(feature = "uuid-impl")]

--- a/diffus/src/diffable_impls/primitives.rs
+++ b/diffus/src/diffable_impls/primitives.rs
@@ -19,8 +19,6 @@ macro_rules! primitive_impl {
     }
 }
 
-pub(crate) use primitive_impl;
-
 primitive_impl! { i64, i32, i16, i8, u64, u32, u16, u8, char, bool, isize, usize, f32, f64, () }
 
 #[cfg(feature = "uuid-impl")]

--- a/diffus/src/same.rs
+++ b/diffus/src/same.rs
@@ -1,4 +1,5 @@
 use crate::Same;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 impl<T: Same> Same for Option<T> {
     fn same(&self, other: &Self) -> bool {
@@ -22,7 +23,8 @@ macro_rules! same_for_eq {
     }
 }
 
-same_for_eq! { i64, i32, i16, i8, u64, u32, u16, u8, char, str, bool, isize, usize, () }
+same_for_eq! { i64, i32, i16, i8, u64, u32, u16, u8, char, str, bool, String, isize, usize, () }
+same_for_eq! { IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6 }
 
 macro_rules! same_for_float {
     ($($typ:ty),*) => {


### PR DESCRIPTION
* Add a `#[diffus_ignore]` attribute to the derive macro to allows us to ignore fields in diffs, such as timestamps.
* Implement `Debug` for macro generated structs
* Implement `Diffable and Same` for IP related types from the standard library
* Implement `Same` for `String`
* Fix a warning introduced in newer rust versions