### PR TITLE
Add stuff needed for use in Omicron (#1)

### DIFF
--- a/diffus/src/diffable_impls/borrow.rs
+++ b/diffus/src/diffable_impls/borrow.rs
@@ -49,6 +49,7 @@ mod tests {
         let left = 13;
         let right = 37;
 
+        #[allow(unused_allocation)]
         if let edit::Edit::Change(diff) = Box::new(left).diff(&Box::new(right)) {
             assert_eq!(*diff, (&13, &37));
         }

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -1,0 +1,108 @@
+use crate::{
+    edit::{self, enm},
+    Diffable,
+};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+macro_rules! struct_impl {
+    ($($typ:ty),*) => {
+        $(
+            impl<'a> Diffable<'a> for $typ {
+                type Diff = (&'a $typ, &'a $typ);
+
+                fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+                    if self == other {
+                        edit::Edit::Copy(self)
+                    } else {
+                        edit::Edit::Change((self, other))
+                    }
+                }
+            }
+        )*
+    }
+}
+
+struct_impl! { Ipv4Addr, Ipv6Addr,  SocketAddrV4, SocketAddrV6}
+
+macro_rules! ip_impl {
+    ($($typ:tt),*) => {
+        $(
+            impl<'a> Diffable<'a> for $typ {
+                type Diff = enm::Edit<'a, Self, (&'a Self, &'a Self)>;
+
+                fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
+                    match (self, other) {
+                        ($typ::V4(a), $typ::V4(b)) => match a.diff(&b) {
+                            edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                            edit::Edit::Change(_) => {
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
+                            }
+                        },
+                        ($typ::V6(a), $typ::V6(b)) => match a.diff(&b) {
+                            edit::Edit::Copy(_) => edit::Edit::Copy(self),
+                            edit::Edit::Change(_) => {
+                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
+                            }
+                        },
+                        _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+                    }
+                }
+            }
+        )*
+    }
+}
+
+ip_impl! { IpAddr, SocketAddr }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_copy() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        assert!(localhost_v4.clone().diff(&localhost_v4).is_copy());
+        assert!(localhost_v6.clone().diff(&localhost_v6).is_copy());
+        assert!(Some(3).diff(&Some(3)).is_copy());
+    }
+
+    #[test]
+    fn associate_change() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let not_localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        let not_localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2));
+        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
+            localhost_v4.diff(&not_localhost_v4).change()
+        {
+            assert_eq!(a, localhost_v4);
+            assert_eq!(b, not_localhost_v4);
+            assert_ne!(a, b);
+        } else {
+            unreachable!();
+        }
+
+        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
+            localhost_v6.diff(&not_localhost_v6).change()
+        {
+            assert_eq!(a, localhost_v6);
+            assert_eq!(b, not_localhost_v6);
+            assert_ne!(a, b);
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn variant_changed() {
+        let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        if let Some(enm::Edit::VariantChanged(&a, &b)) = localhost_v4.diff(&localhost_v6).change() {
+            assert_eq!(a, localhost_v4);
+            assert_eq!(b, localhost_v6);
+        } else {
+            unreachable!();
+        }
+    }
+}

--- a/diffus/src/diffable_impls/mod.rs
+++ b/diffus/src/diffable_impls/mod.rs
@@ -1,5 +1,6 @@
 pub mod borrow;
 pub mod collection;
+pub mod ip;
 pub mod map;
 pub mod option;
 pub mod primitives;

--- a/diffus/src/same.rs
+++ b/diffus/src/same.rs
@@ -1,4 +1,5 @@
 use crate::Same;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 impl<T: Same> Same for Option<T> {
     fn same(&self, other: &Self) -> bool {
@@ -22,7 +23,8 @@ macro_rules! same_for_eq {
     }
 }
 
-same_for_eq! { i64, i32, i16, i8, u64, u32, u16, u8, char, str, bool, isize, usize, () }
+same_for_eq! { i64, i32, i16, i8, u64, u32, u16, u8, char, str, bool, String, isize, usize, () }
+same_for_eq! { IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6 }
 
 macro_rules! same_for_float {
     ($($typ:ty),*) => {


### PR DESCRIPTION
* Add a `#[diffus(ignore)]` attribute to the derive macro to allows us to ignore fields in diffs, such as timestamps.
* Implement `Debug` for macro generated structs
* Implement `Diffable and Same` for IP related types from the standard library
* Implement `Same` for `String`
* Fix a warning introduced in newer rust versions