### PR TITLE
Provide before and after data for enum associated changes

### DIFF
--- a/README.oxide.md
+++ b/README.oxide.md
@@ -1,4 +1,4 @@
 This fork was made to add a few features necessary for use in Oxide control plane software, namely [Omicron](https://github.com/oxidecomputer/omicron).
 
-We intend to upstream all changes.
+We probably won't end up upstreaming the changes, as they are getting more and more invasive.
 

--- a/diffus-derive-test/src/lib.rs
+++ b/diffus-derive-test/src/lib.rs
@@ -118,7 +118,7 @@ mod test {
         }
     }
 
-    #[derive(Diffus)]
+    #[derive(Debug, Diffus, PartialEq, Eq)]
     enum NestedTest {
         T { test: Test },
     }
@@ -197,11 +197,26 @@ mod test {
 
         let diff = left.diff(&right);
 
-        if let edit::enm::Edit::AssociatedChanged(EditedNestedTest::T { test }) =
-            diff.change().unwrap()
+        if let edit::enm::Edit::AssociatedChanged {
+            before,
+            after,
+            diff: EditedNestedTest::T { test },
+        } = diff.change().unwrap()
         {
-            if let edit::enm::Edit::AssociatedChanged(EditedTest::C { x }) = test.change().unwrap()
+            assert_eq!(**before, left);
+            assert_eq!(**after, right);
+
+            if let edit::enm::Edit::AssociatedChanged {
+                before,
+                after,
+                diff: EditedTest::C { x },
+                ..
+            } = test.change().unwrap()
             {
+                let NestedTest::T { test: left_inner } = &left;
+                let NestedTest::T { test: right_inner } = &right;
+                assert_eq!(*before, left_inner);
+                assert_eq!(*after, right_inner);
                 assert_eq!(x.change(), Some(&(&32, &43)));
             } else {
                 unreachable!();
@@ -243,9 +258,14 @@ mod test {
             x: 42,
             y: "Frodo Baggins".to_owned(),
         };
-        if let edit::Edit::Change(edit::enm::Edit::AssociatedChanged(EditedTest::Cd { x, y })) =
-            left.diff(&right)
+        if let edit::Edit::Change(edit::enm::Edit::AssociatedChanged {
+            before,
+            after,
+            diff: EditedTest::Cd { x, y },
+        }) = left.diff(&right)
         {
+            assert_eq!(before, &left);
+            assert_eq!(after, &right);
             assert!(x.is_copy());
             assert!(y.is_change());
         } else {

--- a/diffus-derive/src/lib.rs
+++ b/diffus-derive/src/lib.rs
@@ -243,16 +243,18 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
                         quote! {
                             (
-                                #ident::#variant_ident { #self_field_idents },
-                                #ident::#variant_ident { #other_field_idents }
+                                before @ #ident::#variant_ident { #self_field_idents },
+                                after @ #ident::#variant_ident { #other_field_idents }
                             ) => {
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
                                     ( #just_field_idents ) => {
                                         diffus::edit::Edit::Change(
-                                            diffus::edit::enm::Edit::AssociatedChanged(
-                                                #edited_ident::#variant_ident { #just_field_idents }
-                                            )
+                                            diffus::edit::enm::Edit::AssociatedChanged{
+                                                before,
+                                                after,
+                                                diff: #edited_ident::#variant_ident { #just_field_idents }
+                                            }
                                         )
                                     }
                                 }
@@ -262,16 +264,18 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                     syn::Fields::Unnamed(syn::FieldsUnnamed { .. }) => {
                         quote! {
                             (
-                                #ident::#variant_ident( #self_field_idents ),
-                                #ident::#variant_ident( #other_field_idents )
+                                before @ #ident::#variant_ident( #self_field_idents ),
+                                after @ #ident::#variant_ident( #other_field_idents )
                             ) => {
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
                                     ( #just_field_idents ) => {
                                         diffus::edit::Edit::Change(
-                                            diffus::edit::enm::Edit::AssociatedChanged(
-                                                #edited_ident::#variant_ident ( #just_field_idents )
-                                            )
+                                            diffus::edit::enm::Edit::AssociatedChanged{
+                                                before,
+                                                after,
+                                                diff: #edited_ident::#variant_ident ( #just_field_idents )
+                                            }
                                         )
                                     }
                                 }

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -38,13 +38,13 @@ macro_rules! ip_impl {
                         ($typ::V4(a), $typ::V4(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged{before: self, after: other, diff: (self, other)})
+                                edit::Edit::Change(enm::Edit::AssociatedChanged{ before: self, after: other, diff: (self, other) })
                             }
                         },
                         ($typ::V6(a), $typ::V6(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged{before: self, after: other, diff: (self, other)})
+                                edit::Edit::Change(enm::Edit::AssociatedChanged{ before: self, after: other, diff: (self, other) })
                             }
                         },
                         _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -24,6 +24,9 @@ macro_rules! struct_impl {
 
 struct_impl! { Ipv4Addr, Ipv6Addr,  SocketAddrV4, SocketAddrV6}
 
+// This differs from the `Option` implementation because there is more than one
+// possible variant that contains data. We just return the outer types in the
+// diff for a simple macro implementation.
 macro_rules! ip_impl {
     ($($typ:tt),*) => {
         $(
@@ -35,13 +38,13 @@ macro_rules! ip_impl {
                         ($typ::V4(a), $typ::V4(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
+                                edit::Edit::Change(enm::Edit::AssociatedChanged{before: self, after: other, diff: (self, other)})
                             }
                         },
                         ($typ::V6(a), $typ::V6(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
                             edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged((self, other)))
+                                edit::Edit::Change(enm::Edit::AssociatedChanged{before: self, after: other, diff: (self, other)})
                             }
                         },
                         _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
@@ -98,9 +101,14 @@ mod tests {
         let not_localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
         let localhost_v6 = IpAddr::V6(Ipv6Addr::LOCALHOST);
         let not_localhost_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2));
-        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
-            localhost_v4.diff(&not_localhost_v4).change()
+        if let Some(enm::Edit::AssociatedChanged {
+            before,
+            after,
+            diff: (&a, &b),
+        }) = localhost_v4.diff(&not_localhost_v4).change()
         {
+            assert_eq!(a, **before);
+            assert_eq!(b, **after);
             assert_eq!(a, localhost_v4);
             assert_eq!(b, not_localhost_v4);
             assert_ne!(a, b);
@@ -108,9 +116,14 @@ mod tests {
             unreachable!();
         }
 
-        if let Some(enm::Edit::AssociatedChanged((&a, &b))) =
-            localhost_v6.diff(&not_localhost_v6).change()
+        if let Some(enm::Edit::AssociatedChanged {
+            before,
+            after,
+            diff: (&a, &b),
+        }) = localhost_v6.diff(&not_localhost_v6).change()
         {
+            assert_eq!(a, **before);
+            assert_eq!(b, **after);
             assert_eq!(a, localhost_v6);
             assert_eq!(b, not_localhost_v6);
             assert_ne!(a, b);

--- a/diffus/src/diffable_impls/option.rs
+++ b/diffus/src/diffable_impls/option.rs
@@ -11,7 +11,11 @@ impl<'a, T: Diffable<'a> + 'a> Diffable<'a> for Option<T> {
             (None, None) => edit::Edit::Copy(self),
             (Some(a), Some(b)) => match a.diff(&b) {
                 edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(diff) => edit::Edit::Change(enm::Edit::AssociatedChanged(diff)),
+                edit::Edit::Change(diff) => edit::Edit::Change(enm::Edit::AssociatedChanged {
+                    before: self,
+                    after: other,
+                    diff,
+                }),
             },
             _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
         }
@@ -38,7 +42,12 @@ mod tests {
 
     #[test]
     fn associate_change() {
-        if let Some(enm::Edit::AssociatedChanged((&1, &2))) = Some(1).diff(&Some(2)).change() {
+        if let Some(enm::Edit::AssociatedChanged {
+            before: &Some(1),
+            after: &Some(2),
+            diff: (&1, &2),
+        }) = Some(1).diff(&Some(2)).change()
+        {
         } else {
             unreachable!();
         }

--- a/diffus/src/edit/enm.rs
+++ b/diffus/src/edit/enm.rs
@@ -3,7 +3,11 @@
 pub enum Edit<'a, T: ?Sized, Diff> {
     Copy(&'a T),
     VariantChanged(&'a T, &'a T),
-    AssociatedChanged(Diff),
+    AssociatedChanged {
+        before: &'a T,
+        after: &'a T,
+        diff: Diff,
+    },
 }
 
 impl<'a, T: ?Sized, Diff> Edit<'a, T, Diff> {
@@ -24,7 +28,7 @@ impl<'a, T: ?Sized, Diff> Edit<'a, T, Diff> {
     }
 
     pub fn is_associated_changed(&self) -> bool {
-        if let Self::AssociatedChanged(_) = self {
+        if let Self::AssociatedChanged { .. } = self {
             true
         } else {
             false
@@ -40,8 +44,8 @@ impl<'a, T: ?Sized, Diff> Edit<'a, T, Diff> {
     }
 
     pub fn associated_change(&self) -> Option<&Diff> {
-        if let Self::AssociatedChanged(value) = self {
-            Some(value)
+        if let Self::AssociatedChanged { diff, .. } = self {
+            Some(diff)
         } else {
             None
         }

--- a/diffus/src/edit/enm.rs
+++ b/diffus/src/edit/enm.rs
@@ -1,7 +1,6 @@
 #[cfg_attr(feature = "serialize-impl", derive(serde::Serialize))]
 #[derive(Debug, Eq, PartialEq)]
 pub enum Edit<'a, T: ?Sized, Diff> {
-    Copy(&'a T),
     VariantChanged(&'a T, &'a T),
     AssociatedChanged {
         before: &'a T,
@@ -11,14 +10,6 @@ pub enum Edit<'a, T: ?Sized, Diff> {
 }
 
 impl<'a, T: ?Sized, Diff> Edit<'a, T, Diff> {
-    pub fn is_copy(&self) -> bool {
-        if let Self::Copy(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
     pub fn is_variant_changed(&self) -> bool {
         if let Self::VariantChanged(_, _) = self {
             true


### PR DESCRIPTION
Providing before and after contexts, allows users to stop the recursion at a depth of their choosing by getting back the original values.

We'll probably also want to do something similar for struct fields.