### PR TITLE
Provide before and after values for all changes

### DIFF
--- a/diffus-derive-test/src/lib.rs
+++ b/diffus-derive-test/src/lib.rs
@@ -20,10 +20,14 @@ mod test {
 
     #[test]
     fn vis_check() {
-        if let edit::Edit::Change(hide::EditedInside {
-            p: edit::Edit::Change(diff),
+        if let edit::Edit::Change {
+            diff:
+                hide::EditedInside {
+                    p: edit::Edit::Change { diff, .. },
+                    ..
+                },
             ..
-        }) = hide::Inside::new(0).diff(&hide::Inside::new(1))
+        } = hide::Inside::new(0).diff(&hide::Inside::new(1))
         {
             assert_eq!(diff, (&0, &1));
         } else {
@@ -70,14 +74,18 @@ mod test {
 
         use edit::{self, collection};
 
-        if let edit::Edit::Change(diff) = diff {
+        if let edit::Edit::Change { diff, .. } = diff {
             let diff = diff.into_iter().collect::<Vec<_>>();
 
             if let (
-                &collection::Edit::Change(EditedIdentified {
-                    id: edit::Edit::Copy(&2),
-                    value: edit::Edit::Change((&0, &1)),
-                }),
+                &collection::Edit::Change {
+                    diff:
+                        EditedIdentified {
+                            id: edit::Edit::Copy(&2),
+                            value: edit::Edit::Change { diff: (&0, &1), .. },
+                        },
+                    ..
+                },
                 &collection::Edit::Remove(&Identified { id: 3, value: 0 }),
                 &collection::Edit::Copy(&Identified { id: 4, value: 0 }),
                 &collection::Edit::Insert(&Identified { id: 3, value: 0 }),
@@ -100,15 +108,19 @@ mod test {
 
         use edit::{self, collection};
 
-        if let edit::Edit::Change(diff) = diff {
+        if let edit::Edit::Change { diff, .. } = diff {
             let diff = diff.into_iter().collect::<Vec<_>>();
 
             assert_eq!(diff.len(), 1);
 
-            if let &collection::Edit::Change(EditedIdentified {
-                id: edit::Edit::Copy(&1),
-                value: edit::Edit::Change((&0, &1)),
-            }) = &diff[0]
+            if let &collection::Edit::Change {
+                diff:
+                    EditedIdentified {
+                        id: edit::Edit::Copy(&1),
+                        value: edit::Edit::Change { diff: (&0, &1), .. },
+                    },
+                ..
+            } = &diff[0]
             {
             } else {
                 unreachable!()
@@ -258,11 +270,15 @@ mod test {
             x: 42,
             y: "Frodo Baggins".to_owned(),
         };
-        if let edit::Edit::Change(edit::enm::Edit::AssociatedChanged {
-            before,
-            after,
-            diff: EditedTest::Cd { x, y },
-        }) = left.diff(&right)
+        if let edit::Edit::Change {
+            diff:
+                edit::enm::Edit::AssociatedChanged {
+                    before,
+                    after,
+                    diff: EditedTest::Cd { x, y },
+                },
+            ..
+        } = left.diff(&right)
         {
             assert_eq!(before, &left);
             assert_eq!(after, &right);
@@ -280,7 +296,11 @@ mod test {
             y: "Bilbo Baggins".to_owned(),
         };
         let right = Test::B("Frodo Baggins".to_owned());
-        if let edit::Edit::Change(edit::enm::Edit::VariantChanged(l, r)) = left.diff(&right) {
+        if let edit::Edit::Change {
+            diff: edit::enm::Edit::VariantChanged(l, r),
+            ..
+        } = left.diff(&right)
+        {
             assert_eq!(&left, l);
             assert_eq!(&right, r);
         } else {

--- a/diffus-derive/src/lib.rs
+++ b/diffus-derive/src/lib.rs
@@ -249,13 +249,15 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
                                     ( #just_field_idents ) => {
-                                        diffus::edit::Edit::Change(
-                                            diffus::edit::enm::Edit::AssociatedChanged{
+                                        diffus::edit::Edit::Change { 
+                                            before, 
+                                            after,
+                                            diff: diffus::edit::enm::Edit::AssociatedChanged{
                                                 before,
                                                 after,
                                                 diff: #edited_ident::#variant_ident { #just_field_idents }
                                             }
-                                        )
+                                        }
                                     }
                                 }
                             }
@@ -270,13 +272,15 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
                                     ( #just_field_idents ) => {
-                                        diffus::edit::Edit::Change(
-                                            diffus::edit::enm::Edit::AssociatedChanged{
+                                        diffus::edit::Edit::Change {
+                                            before,
+                                            after,
+                                            diff: diffus::edit::enm::Edit::AssociatedChanged {
                                                 before,
                                                 after,
                                                 diff: #edited_ident::#variant_ident ( #just_field_idents )
                                             }
-                                        )
+                                        }
                                     }
                                 }
                             }
@@ -307,9 +311,12 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                     fn diff(&#impl_lifetime self, other: &#impl_lifetime Self) -> diffus::edit::Edit<#impl_lifetime, Self> {
                         match (self, other) {
                             #(#variants_matches,)*
-                            (self_variant, other_variant) => diffus::edit::Edit::Change(diffus::edit::enm::Edit::VariantChanged(
-                                self_variant, other_variant
-                            )),
+                            (self_variant, other_variant) => diffus::edit::Edit::Change {
+                                before: self_variant,
+                                after: other_variant,
+                                diff: diffus::edit::enm::Edit::VariantChanged(
+                                    self_variant, other_variant
+                            )},
                         }
                     }
                 }
@@ -335,9 +342,11 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                             fn diff(&#impl_lifetime self, other: &#impl_lifetime Self) -> diffus::edit::Edit<#impl_lifetime, Self> {
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
-                                    ( #field_idents ) => diffus::edit::Edit::Change(
-                                        #edited_ident { #field_idents }
-                                    )
+                                    ( #field_idents ) => diffus::edit::Edit::Change {
+                                        before: self,
+                                        after: other,
+                                        diff: #edited_ident { #field_idents }
+                                    }
                                 }
                             }
                         }
@@ -354,9 +363,11 @@ pub fn derive_diffus(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                             fn diff(&#impl_lifetime self, other: &#impl_lifetime Self) -> diffus::edit::Edit<#impl_lifetime, Self> {
                                 match ( #field_diffs ) {
                                     #matches_all_copy,
-                                    ( #field_idents ) => diffus::edit::Edit::Change(
-                                        #edited_ident ( #field_idents )
-                                    )
+                                    ( #field_idents ) => diffus::edit::Edit::Change {
+                                        before: self,
+                                        after: other,
+                                        diff: #edited_ident ( #field_idents )
+                                    }
                                 }
                             }
                         }

--- a/diffus/Cargo.toml
+++ b/diffus/Cargo.toml
@@ -32,7 +32,8 @@ path = "src/lib.rs"
 itertools = "0.10"
 
 indexmap = { version = "1", optional = true }
-newtype-uuid = { version = "1.1.3", optional = true }
+#newtype-uuid = { version = "1.1.3", optional = true }
+newtype-uuid = { path = "../../newtype-uuid/crates/newtype-uuid", optional = true }
 oxnet = { git = "https://github.com/oxidecomputer/oxnet", optional = true }
 uuid = { version = ">=0.5", optional = true }
 snake_case = { version = "0.3", optional = true }

--- a/diffus/Cargo.toml
+++ b/diffus/Cargo.toml
@@ -32,8 +32,7 @@ path = "src/lib.rs"
 itertools = "0.10"
 
 indexmap = { version = "1", optional = true }
-#newtype-uuid = { version = "1.1.3", optional = true }
-newtype-uuid = { path = "../../newtype-uuid/crates/newtype-uuid", optional = true }
+newtype-uuid = { version = "1.2.1", optional = true }
 oxnet = { git = "https://github.com/oxidecomputer/oxnet", optional = true }
 uuid = { version = ">=0.5", optional = true }
 snake_case = { version = "0.3", optional = true }

--- a/diffus/src/diffable_impls/borrow.rs
+++ b/diffus/src/diffable_impls/borrow.rs
@@ -9,7 +9,11 @@ where
 {
     match left.borrow().diff(right.borrow()) {
         edit::Edit::Copy(_) => edit::Edit::Copy(left),
-        edit::Edit::Change(diff) => edit::Edit::Change(diff.into()),
+        edit::Edit::Change { diff, .. } => edit::Edit::Change {
+            before: left,
+            after: right,
+            diff: diff.into(),
+        },
     }
 }
 
@@ -50,7 +54,7 @@ mod tests {
         let right = 37;
 
         #[allow(unused_allocation)]
-        if let edit::Edit::Change(diff) = Box::new(left).diff(&Box::new(right)) {
+        if let edit::Edit::Change { diff, .. } = Box::new(left).diff(&Box::new(right)) {
             assert_eq!(*diff, (&13, &37));
         }
     }
@@ -60,7 +64,7 @@ mod tests {
         let left = 13;
         let right = 37;
 
-        if let edit::Edit::Change(diff) = Rc::new(left).diff(&Rc::new(right)) {
+        if let edit::Edit::Change { diff, .. } = Rc::new(left).diff(&Rc::new(right)) {
             assert_eq!(*diff, (&13, &37));
         }
     }
@@ -70,7 +74,7 @@ mod tests {
         let left = 13;
         let right = 37;
 
-        if let edit::Edit::Change(diff) = Arc::new(left).diff(&Arc::new(right)) {
+        if let edit::Edit::Change { diff, .. } = Arc::new(left).diff(&Arc::new(right)) {
             assert_eq!(*diff, (&13, &37));
         }
     }
@@ -80,7 +84,7 @@ mod tests {
         let left = 13;
         let right = 37;
 
-        if let edit::Edit::Change(diff) = (&left).diff(&(&right)) {
+        if let edit::Edit::Change { diff, .. } = (&left).diff(&(&right)) {
             assert_eq!(diff, (&13, &37));
         }
     }

--- a/diffus/src/diffable_impls/collection.rs
+++ b/diffus/src/diffable_impls/collection.rs
@@ -24,7 +24,7 @@ macro_rules! collection_impl {
                     if s.iter().all(collection::Edit::is_copy) {
                         edit::Edit::Copy(self)
                     } else {
-                        edit::Edit::Change(s)
+                        edit::Edit::Change{before: self, after: other, diff: s}
                     }
                 }
             }
@@ -49,7 +49,7 @@ mod tests {
         let right = b"MZJAWXU".to_vec();
 
         let diff = left.diff(&right);
-        if let edit::Edit::Change(diff) = diff {
+        if let edit::Edit::Change { diff, .. } = diff {
             use collection::Edit::*;
 
             assert_eq!(

--- a/diffus/src/diffable_impls/ip.rs
+++ b/diffus/src/diffable_impls/ip.rs
@@ -14,7 +14,11 @@ macro_rules! struct_impl {
                     if self == other {
                         edit::Edit::Copy(self)
                     } else {
-                        edit::Edit::Change((self, other))
+                        edit::Edit::Change {
+                            before: self,
+                            after: other,
+                            diff: (self, other)
+                        }
                     }
                 }
             }
@@ -37,17 +41,37 @@ macro_rules! ip_impl {
                     match (self, other) {
                         ($typ::V4(a), $typ::V4(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                            edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged{ before: self, after: other, diff: (self, other) })
+                            edit::Edit::Change{..} => {
+                                edit::Edit::Change{
+                                    before: self,
+                                    after: other,
+                                    diff: enm::Edit::AssociatedChanged{
+                                        before: self,
+                                        after: other,
+                                        diff: (self, other)
+                                    }
+                                }
                             }
                         },
                         ($typ::V6(a), $typ::V6(b)) => match a.diff(&b) {
                             edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                            edit::Edit::Change(_) => {
-                                edit::Edit::Change(enm::Edit::AssociatedChanged{ before: self, after: other, diff: (self, other) })
+                            edit::Edit::Change{..} => {
+                                edit::Edit::Change{
+                                    before: self,
+                                    after: other,
+                                    diff: enm::Edit::AssociatedChanged{
+                                        before: self,
+                                        after: other,
+                                        diff: (self, other)
+                                    }
+                                }
                             }
                         },
-                        _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+                        _ => edit::Edit::Change{
+                            before: self,
+                            after: other,
+                            diff: enm::Edit::VariantChanged(self, other)
+                        },
                     }
                 }
             }

--- a/diffus/src/diffable_impls/map.rs
+++ b/diffus/src/diffable_impls/map.rs
@@ -25,7 +25,7 @@ macro_rules! map_impl {
                         .collect::<$typ<_, _>>();
 
                     if value_diffs.values().any(|v| !v.is_copy()) {
-                        Edit::Change(value_diffs)
+                        Edit::Change{before: self, after: other, diff: value_diffs}
                     } else {
                         Edit::Copy(self)
                     }
@@ -60,7 +60,7 @@ mod tests {
         let not_unity: std::collections::HashMap<_, _> =
             [(1, 1), (2, 3), (4, 4)].iter().cloned().collect();
 
-        if let Edit::Change(diff) = unity.diff(&not_unity) {
+        if let Edit::Change { diff, .. } = unity.diff(&not_unity) {
             assert!(diff[&1].is_copy());
             assert_eq!(diff[&2].change().unwrap(), &(&2, &3));
             assert!(diff[&3].is_remove());

--- a/diffus/src/diffable_impls/option.rs
+++ b/diffus/src/diffable_impls/option.rs
@@ -11,13 +11,21 @@ impl<'a, T: Diffable<'a> + 'a> Diffable<'a> for Option<T> {
             (None, None) => edit::Edit::Copy(self),
             (Some(a), Some(b)) => match a.diff(&b) {
                 edit::Edit::Copy(_) => edit::Edit::Copy(self),
-                edit::Edit::Change(diff) => edit::Edit::Change(enm::Edit::AssociatedChanged {
+                edit::Edit::Change { diff, .. } => edit::Edit::Change {
                     before: self,
                     after: other,
-                    diff,
-                }),
+                    diff: enm::Edit::AssociatedChanged {
+                        before: self,
+                        after: other,
+                        diff,
+                    },
+                },
             },
-            _ => edit::Edit::Change(enm::Edit::VariantChanged(self, other)),
+            _ => edit::Edit::Change {
+                before: self,
+                after: other,
+                diff: enm::Edit::VariantChanged(self, other),
+            },
         }
     }
 }

--- a/diffus/src/diffable_impls/primitives.rs
+++ b/diffus/src/diffable_impls/primitives.rs
@@ -11,7 +11,7 @@ macro_rules! primitive_impl {
                     if self.same(other) {
                         edit::Edit::Copy(self)
                     } else {
-                        edit::Edit::Change((self, other))
+                        edit::Edit::Change{before: self, after: other, diff: (self, other)}
                     }
                 }
             }

--- a/diffus/src/diffable_impls/set.rs
+++ b/diffus/src/diffable_impls/set.rs
@@ -25,7 +25,7 @@ macro_rules! set_impl {
                         .collect::<$diff_type<_, _>>();
 
                     if value_diffs.iter().any(|(_, edit)| !edit.is_copy()) {
-                        Edit::Change(value_diffs)
+                        Edit::Change{before: self, after: other, diff: value_diffs}
                     } else {
                         Edit::Copy(self)
                     }
@@ -58,7 +58,7 @@ mod tests {
         let unity: std::collections::HashSet<_, _> = [1, 2, 3].iter().cloned().collect();
         let not_unity: std::collections::HashSet<_, _> = [1, 2, 4].iter().cloned().collect();
 
-        if let Edit::Change(diff) = unity.diff(&not_unity) {
+        if let Edit::Change { diff, .. } = unity.diff(&not_unity) {
             assert!(diff[&1].is_copy());
             assert!(diff[&2].is_copy());
             assert!(diff[&3].is_remove());

--- a/diffus/src/diffable_impls/string.rs
+++ b/diffus/src/diffable_impls/string.rs
@@ -19,7 +19,11 @@ impl<'a> Diffable<'a> for str {
         if s.iter().all(string::Edit::is_copy) {
             edit::Edit::Copy(self)
         } else {
-            edit::Edit::Change(s)
+            edit::Edit::Change {
+                before: self,
+                after: other,
+                diff: s,
+            }
         }
     }
 }
@@ -29,7 +33,11 @@ impl<'a> Diffable<'a> for String {
 
     fn diff(&'a self, other: &'a Self) -> edit::Edit<Self> {
         match self.as_str().diff(other.as_str()) {
-            edit::Edit::Change(diff) => edit::Edit::Change(diff),
+            edit::Edit::Change { diff, .. } => edit::Edit::Change {
+                before: self,
+                after: other,
+                diff,
+            },
             edit::Edit::Copy(_) => edit::Edit::Copy(self),
         }
     }
@@ -47,7 +55,7 @@ mod tests {
         let right = "MZJAWXU".to_owned();
 
         let diff = left.diff(&right);
-        if let edit::Edit::Change(diff) = diff {
+        if let edit::Edit::Change { diff, .. } = diff {
             assert_eq!(
                 diff.into_iter().collect::<Vec<_>>(),
                 vec![
@@ -76,7 +84,7 @@ mod tests {
         let right = "MZJAWXU";
 
         let diff = left.diff(&right);
-        if let edit::Edit::Change(diff) = diff {
+        if let edit::Edit::Change { diff, .. } = diff {
             assert_eq!(
                 diff.into_iter().collect::<Vec<_>>(),
                 vec![

--- a/diffus/src/diffable_impls/typed_uuid.rs
+++ b/diffus/src/diffable_impls/typed_uuid.rs
@@ -12,7 +12,11 @@ where
         if self == other {
             edit::Edit::Copy(self)
         } else {
-            edit::Edit::Change((self, other))
+            edit::Edit::Change {
+                before: self,
+                after: other,
+                diff: (self, other),
+            }
         }
     }
 }

--- a/diffus/src/edit/collection.rs
+++ b/diffus/src/edit/collection.rs
@@ -6,7 +6,11 @@ pub enum Edit<'a, T: ?Sized, Diff> {
     Copy(&'a T),
     Insert(&'a T),
     Remove(&'a T),
-    Change(Diff),
+    Change {
+        before: &'a T,
+        after: &'a T,
+        diff: Diff,
+    },
 }
 
 impl<'a, T: Same + ?Sized, Diff> Edit<'a, T, Diff> {
@@ -63,8 +67,8 @@ impl<'a, T: Same + ?Sized, Diff> Edit<'a, T, Diff> {
     }
 
     pub fn change(&self) -> Option<&Diff> {
-        if let Self::Change(value) = self {
-            Some(value)
+        if let Self::Change { diff, .. } = self {
+            Some(diff)
         } else {
             None
         }

--- a/diffus/src/edit/map.rs
+++ b/diffus/src/edit/map.rs
@@ -6,7 +6,11 @@ pub enum Edit<'a, T: Diffable<'a> + ?Sized> {
     Copy(&'a T),
     Insert(&'a T),
     Remove(&'a T),
-    Change(T::Diff),
+    Change {
+        before: &'a T,
+        after: &'a T,
+        diff: T::Diff,
+    },
 }
 
 impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
@@ -41,7 +45,7 @@ impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
         }
     }
     pub fn is_change(&self) -> bool {
-        if let Self::Change(_) = self {
+        if let Self::Change { .. } = self {
             true
         } else {
             false
@@ -62,8 +66,8 @@ impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
         }
     }
     pub fn change(&self) -> Option<&T::Diff> {
-        if let Self::Change(value_diff) = self {
-            Some(value_diff)
+        if let Self::Change { diff, .. } = self {
+            Some(diff)
         } else {
             None
         }

--- a/diffus/src/edit/mod.rs
+++ b/diffus/src/edit/mod.rs
@@ -10,7 +10,11 @@ use crate::Diffable;
 #[derive(Debug, PartialEq, Eq)]
 pub enum Edit<'a, T: Diffable<'a> + ?Sized> {
     Copy(&'a T),
-    Change(T::Diff),
+    Change {
+        before: &'a T,
+        after: &'a T,
+        diff: T::Diff,
+    },
 }
 
 impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
@@ -31,7 +35,7 @@ impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
     }
 
     pub fn is_change(&self) -> bool {
-        if let Self::Change(_) = self {
+        if let Self::Change { .. } = self {
             true
         } else {
             false
@@ -39,8 +43,8 @@ impl<'a, T: Diffable<'a> + ?Sized> Edit<'a, T> {
     }
 
     pub fn change(&self) -> Option<&T::Diff> {
-        if let Self::Change(value_diff) = self {
-            Some(value_diff)
+        if let Self::Change { diff, .. } = self {
+            Some(diff)
         } else {
             None
         }
@@ -51,7 +55,15 @@ impl<'a, Diff, T: Diffable<'a, Diff = Diff> + 'a> Into<map::Edit<'a, T>> for Edi
     fn into(self) -> map::Edit<'a, T> {
         match self {
             Self::Copy(value) => map::Edit::Copy(value),
-            Self::Change(diff) => map::Edit::Change(diff),
+            Self::Change {
+                before,
+                after,
+                diff,
+            } => map::Edit::Change {
+                before,
+                after,
+                diff,
+            },
         }
     }
 }

--- a/diffus/src/lcs.rs
+++ b/diffus/src/lcs.rs
@@ -155,7 +155,15 @@ pub(crate) fn lcs_post_change<'a, T: Same + Diffable<'a> + ?Sized + 'a>(
     result.map(|edit| match edit {
         Edit::Same(left, right) => match left.diff(right) {
             edit::Edit::Copy(t) => edit::collection::Edit::Copy(t),
-            edit::Edit::Change(diff) => edit::collection::Edit::Change(diff),
+            edit::Edit::Change {
+                before,
+                after,
+                diff,
+            } => edit::collection::Edit::Change {
+                before,
+                after,
+                diff,
+            },
         },
         Edit::Insert(value) => edit::collection::Edit::Insert(value),
         Edit::Remove(value) => edit::collection::Edit::Remove(value),


### PR DESCRIPTION
This adds redundant information in some cases, but it is cheap since the redundant info is all references.